### PR TITLE
1.4.1

### DIFF
--- a/Chet.QuartzNet.UI.nuspec
+++ b/Chet.QuartzNet.UI.nuspec
@@ -23,10 +23,10 @@
 				<dependency id="Microsoft.Extensions.FileProviders.Embedded" version="8.0.0" />
 				<dependency id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" />
 				<dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="8.0.0" />
-				<dependency id="Quartz" version="3.8.0" />
-				<dependency id="Quartz.AspNetCore" version="3.8.0" />
-				<dependency id="Quartz.Extensions.DependencyInjection" version="3.8.0" />
-				<dependency id="Quartz.Extensions.Hosting" version="3.8.0" />
+				<dependency id="Quartz" version="3.15.1" />
+				<dependency id="Quartz.AspNetCore" version="3.15.1" />
+				<dependency id="Quartz.Extensions.DependencyInjection" version="3.15.1" />
+				<dependency id="Quartz.Extensions.Hosting" version="3.15.1" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/test/Chet.QuartzNet.Database.Test/Chet.QuartzNet.Database.Test.csproj
+++ b/test/Chet.QuartzNet.Database.Test/Chet.QuartzNet.Database.Test.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chet.QuartzNet.EFCore.MySQL" Version="1.3.2" />
-    <PackageReference Include="Chet.QuartzNet.EFCore.PostgreSQL" Version="1.3.2" />
-    <PackageReference Include="Chet.QuartzNet.EFCore.SQLite" Version="1.3.2" />
-    <PackageReference Include="Chet.QuartzNet.EFCore.SqlServer" Version="1.3.2" />
-    <PackageReference Include="Chet.QuartzNet.UI" Version="1.3.2" />
+    <PackageReference Include="Chet.QuartzNet.EFCore.MySQL" Version="1.4.0" />
+    <PackageReference Include="Chet.QuartzNet.EFCore.PostgreSQL" Version="1.4.0" />
+    <PackageReference Include="Chet.QuartzNet.EFCore.SQLite" Version="1.4.0" />
+    <PackageReference Include="Chet.QuartzNet.EFCore.SqlServer" Version="1.4.0" />
+    <PackageReference Include="Chet.QuartzNet.UI" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Chet.QuartzNet.File.Test/Chet.QuartzNet.File.Test.csproj
+++ b/test/Chet.QuartzNet.File.Test/Chet.QuartzNet.File.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chet.QuartzNet.UI" Version="1.3.2" />
+    <PackageReference Include="Chet.QuartzNet.UI" Version="1.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
升级Chet.QuartzNet.UI和相关EFCore包至1.4.0版本，同时将Quartz相关依赖从3.8.0更新至3.15.1版本