### PR TITLE
ci(github workflows): 固定pnpm版本为9.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 9.15.0
 
       - name: Cache pnpm dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
将pnpm的安装版本从latest改为固定的9.15.0，避免因latest版本更新导致构建出现兼容性问题。